### PR TITLE
Added MessageId attribute for custom id on Azure Service Bus messages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,13 +122,13 @@ var myMessage = new MyMessage
 {
     MyId = "id",
     A = "a",
-	B = "b"
+    B = "b"
 };
 
 var duplicateMessage = new MyMessage
 {
-    MyId = "id",
-	A = "a",
+    MyId = "id",	
+    A = "a",
     B = "b"
 };
 

--- a/README.md
+++ b/README.md
@@ -99,3 +99,40 @@ var myMessage = new MyMessage
 await publisher.SendAsync(myMessage);
 
 ```
+
+## Sending Message with custom Message Id
+
+To leverage Azure Service Bus duplicate detection the MessageId should be set to an identifier based on your internal business logic. With Fishbus, Azure Service Bus MessageId logic can be overriden by adding the ```[MessageId]``` attribute to your custom message id property.
+
+```csharp
+[MessageLabel("My.Message.With.Custom.MessageId")]
+public class MyMessage
+{
+    [MessageId]
+    public string MyId { get; set; }
+    public string A { get; set; }
+    public string B { get; set; }
+}
+
+...
+
+var publisher = new MessagePublisher(connectionString);
+
+var myMessage = new MyMessage 
+{
+    MyId = "id",
+    A = "a",
+	B = "b"
+};
+
+var duplicateMessage = new MyMessage
+{
+    MyId = "id",
+	A = "a",
+    B = "b"
+};
+
+await publisher.SendAsync(myMessage);
+await publisher.SendAsync(duplicateMessage); // Will be discarded by Azure Service Bus if duplicate detection activated and message sent within the duplicate detection history window.
+```
+

--- a/src/MessageAttributes.cs
+++ b/src/MessageAttributes.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace Thon.Hotels.FishBus
+{
+    public static class MessageAttributes
+    {
+        public static string GetMessageId<T>(T message)
+        {
+            var messageIdAttributes = message.GetType().GetProperties()
+                .Select(pi => new
+                {
+                    Property = pi,
+                    Attribute = pi.GetCustomAttribute(typeof(MessageIdAttribute), true) as MessageIdAttribute
+                })
+                .Where(x => x.Attribute != null)
+                .ToList();
+
+            if (!messageIdAttributes.Any())
+                return string.Empty;
+
+            if (messageIdAttributes.Count > 1)
+                throw new Exception($"At most one property of {message.GetType().Name} can be marked with the {nameof(MessageIdAttribute)} attribute");
+
+            return messageIdAttributes.FirstOrDefault()?.Property.GetValue(message, null) as string;
+        }
+
+        public static string GetMessageLabel<T>(T message)
+        {
+            var label = message.GetType().GetCustomAttribute<MessageLabelAttribute>()?.Label;
+
+            if (string.IsNullOrWhiteSpace(label))
+                throw new Exception($"Label must be specified on {message.GetType().Name} using MessageLabelAttribute");
+
+            return label;
+        }
+    }
+}

--- a/src/MessageIdAttribute.cs
+++ b/src/MessageIdAttribute.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace Thon.Hotels.FishBus
+{
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+    public class MessageIdAttribute : Attribute
+    {
+    }
+}

--- a/src/MessagePublisher.cs
+++ b/src/MessagePublisher.cs
@@ -2,7 +2,6 @@ using Microsoft.Azure.ServiceBus;
 using Microsoft.Azure.ServiceBus.Core;
 using Newtonsoft.Json;
 using System;
-using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -24,17 +23,18 @@ namespace Thon.Hotels.FishBus
 
         public async Task SendAsync<T>(T message)
         {
+            var id = MessageAttributes.GetMessageId(message);
+            var label = MessageAttributes.GetMessageLabel(message);
 
-            var label = message.GetType().GetCustomAttribute<MessageLabelAttribute>()?.Label;
-
-            if (string.IsNullOrWhiteSpace(label))
-                throw new Exception($"Label must be specified on {message.GetType().Name} using MessageLabelAttribute");
-
-
-            await _client.SendAsync(new Message(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(message)))
+            var msg = new Message(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(message)))
             {
                 Label = label
-            });
+            };
+
+            if (!string.IsNullOrWhiteSpace(id))
+                msg.MessageId = id;
+
+            await _client.SendAsync(msg);
         }
     }
 }

--- a/tests/FishbusTests/MessageAttributesTests.cs
+++ b/tests/FishbusTests/MessageAttributesTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace FishbusTests
 {
-    public class MessageHelperTests
+    public class MessageAttributesTests
     {
         [Fact]
         public void MessageWithMessageIdAttributeUseCustomId()

--- a/tests/FishbusTests/MessageHandlers/MessageWithMessageId.cs
+++ b/tests/FishbusTests/MessageHandlers/MessageWithMessageId.cs
@@ -1,0 +1,27 @@
+﻿using Thon.Hotels.FishBus;
+
+namespace FishbusTests.MessageHandlers
+{
+    [MessageLabel("A.Message.With.MessageId")]
+    public class MessageWithMessageId
+    {
+        [MessageId]
+        public string Id { get; set; }
+    }
+
+    [MessageLabel("A.Message.With.Too.Many.MessageIds")]
+    public class MessageWithTooManyMessageIds
+    {
+        [MessageId]
+        public string Id { get; set; }
+        [MessageId]
+        public string AnothterId { get; set; }
+    }
+
+    [MessageLabel("A.Message.Without.MessageId")]
+    public class MessageWithoutMessageId
+    {
+        public string Id { get; set; }
+        public string AnothterId { get; set; }
+    }
+}

--- a/tests/FishbusTests/MessageHelperTests.cs
+++ b/tests/FishbusTests/MessageHelperTests.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using FishbusTests.MessageHandlers;
+using Thon.Hotels.FishBus;
+using Xunit;
+
+namespace FishbusTests
+{
+    public class MessageHelperTests
+    {
+        [Fact]
+        public void MessageWithMessageIdAttributeUseCustomId()
+        {
+            var messageId = "messageId";
+            var messageWithId = new MessageWithMessageId { Id = messageId };
+
+            var value = MessageAttributes.GetMessageId(messageWithId);
+
+            Assert.Equal(messageId, value);
+        }
+
+        [Fact]
+        public void MessageWithMessageIdAttributeUseCustomIdEvenWhenNull()
+        {
+            string messageId = null;
+            var messageWithId = new MessageWithMessageId();
+
+            var value = MessageAttributes.GetMessageId(messageWithId);
+
+            Assert.Equal(messageId, value);
+        }
+
+        [Fact]
+        public void MessageWithMoreThanOneMessageIdAttributeThrowExcption()
+        {
+            var invalidMessage = new MessageWithTooManyMessageIds {Id = "id", AnothterId = "anotherId"};
+
+            Assert.Throws<Exception>(() => MessageAttributes.GetMessageId(invalidMessage));
+        }
+
+        [Fact]
+        public void MessageWithMoreThanOneMessageIdAttributeThrowExcptionEvenWithIdsSetToNull()
+        {
+            var invalidMessage = new MessageWithTooManyMessageIds();
+            Assert.Throws<Exception>(() => MessageAttributes.GetMessageId(invalidMessage));
+        }
+
+        [Fact]
+        public void MessageWithoutMessageIdAttributeIdNotSet()
+        {
+            var messageWithId = new MessageWithoutMessageId();
+
+            var value = MessageAttributes.GetMessageId(messageWithId);
+
+            Assert.Equal(string.Empty, value);
+        }
+    }
+}


### PR DESCRIPTION
To leverage Azure Service Bus duplicate detection the MessageId should be set to an identifier based on your internal business logic.

Azure Service Bus MessageId logic can be overriden by adding the ```[MessageId]``` attribute to your custom message id property.