### PR TITLE
Optional MessageLabelAttribute

### DIFF
--- a/src/MessageBuilder.cs
+++ b/src/MessageBuilder.cs
@@ -34,7 +34,7 @@ namespace Thon.Hotels.FishBus
             var label = message.GetType().GetCustomAttribute<MessageLabelAttribute>()?.Label;
 
             if (string.IsNullOrWhiteSpace(label))
-                throw new Exception($"Label must be specified on {message.GetType().Name} using MessageLabelAttribute");
+                return message.GetType().FullName;
 
             return label;
         }

--- a/tests/FishbusTests/MessageBuilderTests.cs
+++ b/tests/FishbusTests/MessageBuilderTests.cs
@@ -83,5 +83,23 @@ namespace FishbusTests
 
             Assert.True(DateTime.UtcNow.AddHours(23) < msg.ScheduledEnqueueTimeUtc);
         }
+
+        [Fact]
+        public void MessageWithLabelAttributeUsesAttribute()
+        {
+            var messageWithAttribute = new MessageWithLabelAttribute();
+            var msg = MessageBuilder.BuildMessage(messageWithAttribute);
+
+            Assert.Equal("A.Custom.Message.Label", msg.Label);
+        }
+
+        [Fact]
+        public void MessageWithoutLabelAttributeUsesTypeFullName()
+        {
+            var messageWithoutAttribute = new MessageA();
+            var msg = MessageBuilder.BuildMessage(messageWithoutAttribute);
+
+            Assert.Equal(typeof(MessageA).FullName, msg.Label);
+        }
     }
 }


### PR DESCRIPTION
Small change to MessageBuilder so that the Label is set to the message type's full name when no MessageLabelAttribute is present. Brings MessageBuilder into harmony with MessageHandlerRegistry, which already supports this.